### PR TITLE
First stab at Python package and wheel.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,17 @@ enable_testing()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-file(COPY tf_flags.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-execute_process(COMMAND python ${CMAKE_CURRENT_BINARY_DIR}/tf_flags.py OUTPUT_VARIABLE TF_CFG ERROR_QUIET)
+find_package(PythonInterp REQUIRED)
+
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tf_flags.py
+        OUTPUT_VARIABLE TF_CFG
+        RESULT_VARIABLE TF_NOT_FOUND
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if (TF_NOT_FOUND)
+    message(FATAL_ERROR "Tensorflow not found")
+endif ()
+
 list(GET TF_CFG 2 CXX_11_ABI)
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=${CXX_11_ABI})
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,9 +2,6 @@
 
 set -euxo pipefail
 
-mkdir build
-cd build
-cmake ..
-make
-
-ctest -V
+python setup.py bdist_wheel
+pip install dist/*.whl
+python -c "import finalfusion_tensorflow"

--- a/python/finalfusion_tensorflow/__init__.py
+++ b/python/finalfusion_tensorflow/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+
+from finalfusion_tensorflow.ops.finalfusion_ops import ff_embeddings, initialize_ff_embeddings, ff_lookup, \
+    close_ff_embeddings

--- a/python/finalfusion_tensorflow/ops/finalfusion_ops.py
+++ b/python/finalfusion_tensorflow/ops/finalfusion_ops.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import platform
+
+from tensorflow.python.framework import load_library
+from tensorflow.python.platform import resource_loader
+
+if platform.system() == "Darwin":
+    LIB_SUFFIX = ".dylib"
+else:
+    LIB_SUFFIX = ".so"
+
+finalfusion_ops = load_library.load_op_library(
+    resource_loader.get_path_to_datafile('./libfinalfusion_tf' + LIB_SUFFIX))
+
+ff_embeddings = finalfusion_ops.ff_embeddings
+initialize_ff_embeddings = finalfusion_ops.initialize_ff_embeddings
+ff_lookup = finalfusion_ops.ff_lookup
+close_ff_embeddings = finalfusion_ops.close_ff_embeddings

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,125 @@
+import os
+import platform
+import subprocess
+import sys
+
+from distutils.version import LooseVersion
+from setuptools import setup, find_packages, Extension
+from setuptools.command.build_ext import build_ext
+
+if platform.system() == "Darwin":
+    LIB_SUFFIX = ".dylib"
+else:
+    LIB_SUFFIX = ".so"
+
+
+# this method is inspired by horovod's setup.py which can be found at:
+# https://github.com/horovod/horovod/blob/master/setup.py
+def get_compiler_version():
+    if sys.platform.startswith('linux') and not os.getenv('CC') and not os.getenv('CXX'):
+        import tensorflow as tf
+        if hasattr(tf, 'version'):
+            # Since TensorFlow 1.13.0
+            tf_compiler_version = LooseVersion(tf.version.COMPILER_VERSION)
+        else:
+            tf_compiler_version = LooseVersion(tf.COMPILER_VERSION)
+
+        if tf_compiler_version.version[0] == 4:
+            # https://github.com/tensorflow/tensorflow/issues/27067
+            maximum_compiler_version = LooseVersion('5')
+        else:
+            maximum_compiler_version = LooseVersion('999')
+
+        if len(tf_compiler_version.version) == 3:
+            tf_compiler_version = LooseVersion(
+                str(tf_compiler_version.version[0]) + "." + str(tf_compiler_version.version[1]))
+        compiler_version = LooseVersion('0')
+        cur_gcc_path = cur_gxx_path = None
+        # iterate over binaries on PATH
+        for directory in os.getenv('PATH', '').split(':'):
+            if not os.path.exists(directory):
+                continue
+            for bin in os.listdir(directory):
+                if bin.startswith("g++"):
+                    gxx_path = os.path.join(directory, bin)
+                    gxx_cmd = "{0} -dumpversion".format(gxx_path)
+                    gxx_ver = LooseVersion(subprocess.check_output(gxx_cmd, shell=True,
+                                                                   universal_newlines=True).strip())
+                    # check if gxx version is compatible
+                    if maximum_compiler_version > gxx_ver >= tf_compiler_version:
+                        gcc_path = os.path.join(directory, "gcc" + bin[3:])
+                        # verify gcc with same version to g++ exists
+                        if os.path.exists(gcc_path):
+                            gcc_ver_cmd = "{0} -dumpversion".format(gcc_path)
+                            gcc_ver = LooseVersion(
+                                subprocess.check_output(gcc_ver_cmd, shell=True, universal_newlines=True).strip())
+                            # verify that gcc and g++ match and version is higher than currently highest
+                            if gcc_ver == gxx_ver > compiler_version:
+                                cur_gcc_path, cur_gxx_path = gcc_path, gxx_path
+        if cur_gxx_path is None:
+            raise RuntimeError(
+                "Can't find suitable g++ compiler, max version: {0}, min version {1}".format(maximum_compiler_version,
+                                                                                             tf_compiler_version))
+        return cur_gcc_path, cur_gxx_path
+    else:
+        return None
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, cmake_lists_dir='.', **kwargs):
+        Extension.__init__(self, name, sources=[], **kwargs)
+        self.cmake_lists_dir = os.path.abspath(cmake_lists_dir)
+
+
+class cmake_build_ext(build_ext):
+    def build_extensions(self):
+        # Ensure that CMake is present and working
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError('Cannot find CMake executable')
+
+        for ext in self.extensions:
+            extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+            extdir = os.path.join(extdir, ext.name, "ops")
+            cfg = 'Debug' if self.debug else 'Release'
+
+            cmake_args = [
+                '-DCMAKE_BUILD_TYPE=%s' % cfg,
+                '-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), self.build_temp),
+                '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
+            ]
+
+            compilers = get_compiler_version()
+            if compilers:
+                os.environ['CC'], os.environ['CXX'] = compilers
+                print("Compiling with: {0}".format(os.environ['CXX']))
+            # ensure CMake calls same Python exectuable
+            os.environ['PYTHON_EXECUTABLE'] = sys.executable
+            if not os.path.exists(self.build_temp):
+                os.makedirs(self.build_temp)
+
+            subprocess.check_call(['cmake', ext.cmake_lists_dir] + cmake_args,
+                                  cwd=self.build_temp)
+            subprocess.check_call(['cmake', '--build', '.', '--config', cfg],
+                                  cwd=self.build_temp)
+            subprocess.check_call(['ctest', '-V'], cwd=self.build_temp)
+            subprocess.check_call(
+                ['cp', os.path.join(self.build_temp, "finalfusion-tf", "libfinalfusion_tf" + LIB_SUFFIX), extdir])
+
+
+setup(
+    author='The finalfusion authors',
+    cmdclass=dict(build_ext=cmake_build_ext),
+    description='Tensorflow Ops for Finalfusion embeddings.',
+    ext_modules=[CMakeExtension(name='finalfusion_tensorflow')],
+    name="finalfusion_tensorflow",
+    packages=find_packages(where="./python"),
+    package_dir={
+        '': 'python',
+    },
+    setup_requires=["tensorflow"],
+    install_requires=["tensorflow"],
+    url='https://github.com/finalfusion/finalfusion-tensorflow',
+    version='0.1.0',
+)

--- a/tf_flags.py
+++ b/tf_flags.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import platform
 import tensorflow as tf
 


### PR DESCRIPTION
This is the first time I'm writing a Python package and setting up building a wheel. I tried to go with how other tf extensions are built, but I'm not sure whether what I did makes sense. 

`setup.py` in this PR produces usable wheels on Ubuntu for Python 2.7.16, 3.6.7 and 3.7 with pip-installed tensorflow. I haven't set up test infrastructure since I'm not sure how we want to go about testing here, since the pytests are currently implemented on the raw library.

Ideally we'd get rid of the duplicate build of the full library by running `ctest` from within `setup.py`. That was failing because the library output path is set to the `setuptools` build path, so the pytests don't find `libfinalfusion_tensorflow.so` and fail.