### PR TITLE
Remove tensorflow requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,8 +128,6 @@ setup(
     package_dir={
         '': 'python',
     },
-    setup_requires=["tensorflow"],
-    install_requires=["tensorflow"],
     url='https://github.com/finalfusion/finalfusion-tensorflow',
     version='0.1.0',
 )


### PR DESCRIPTION
Can lead to mismatch between the tf distribution returning the compilation flags etc. and the one installed by setup.py.

If e.g. `tensorflow-rocm` is installed, `import tensorflow` in the `cmake` call will import `tensorflow-rocm` which is not necessarily compiled in the same manner as `tensorflow` which is installed as a dependency by the setup.

@twuebi ran into ABI incompatibility issues here since `tensorflow-rocm` is compiled with a different `CXX_11_ABI` flag than the official tensorflow wheels.