### PR TITLE
Fix OP arguments.

### DIFF
--- a/python/finalfusion_tensorflow/ops/finalfusion_ops.py
+++ b/python/finalfusion_tensorflow/ops/finalfusion_ops.py
@@ -15,17 +15,18 @@ else:
 _finalfusion_ops = load_library.load_op_library(resource_filename(__name__, "libfinalfusion_tf" + LIB_SUFFIX))
 
 
-def ff_embeddings(shared_name="", container="", name=""):
-    return _finalfusion_ops.ff_embeddings(shared_name, container, name)
+def ff_embeddings(container="", shared_name="", name=None):
+    return _finalfusion_ops.ff_embeddings(container=container, shared_name=shared_name, name=name)
 
 
-def initialize_ff_embeddings(embeddings, path="", mmap=False, name=""):
-    return _finalfusion_ops.initialize_ff_embeddings(embeddings, path, mmap, name)
+def initialize_ff_embeddings(embeddings, path="", mmap=False, name=None):
+    return _finalfusion_ops.initialize_ff_embeddings(embeddings, path, mmap, name=name)
 
 
-def ff_lookup(embeddings, query, embedding_len=-1, mask_empty_string=False, mask_failed_lookup=False, name=""):
-    return _finalfusion_ops.ff_lookup(embeddings, query, embedding_len, mask_empty_string, mask_failed_lookup, name)
+def ff_lookup(embeddings, query, embedding_len=-1, mask_empty_string=False, mask_failed_lookup=False, name=None):
+    return _finalfusion_ops.ff_lookup(embeddings, query, embedding_len, mask_empty_string, mask_failed_lookup,
+                                      name=name)
 
 
-def close_ff_embeddings(embeddings, name=""):
-    return _finalfusion_ops.close_ff_embeddings(embeddings, name)
+def close_ff_embeddings(embeddings, name=None):
+    return _finalfusion_ops.close_ff_embeddings(embeddings, name=name)


### PR DESCRIPTION
`name` defaulted to the empty string rendering the methods unusable since `""` is not a valid node name.