### PR TITLE
Restrict compiler version to first two digits in all cases.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def get_compiler_version():
         else:
             maximum_compiler_version = LooseVersion('999')
 
-        if len(tf_compiler_version.version) == 3:
+        if len(tf_compiler_version.version) >= 3:
             tf_compiler_version = LooseVersion(
                 str(tf_compiler_version.version[0]) + "." + str(tf_compiler_version.version[1]))
         compiler_version = LooseVersion('0')


### PR DESCRIPTION
Previously, the version was only restricted if len == 3. g++
sometimes returns version strings including a date, thus not
triggering the statement.

@twuebi ran into this issue in a docker container where the compiler version returned by tf was `5.4.0` followed by some date while the available compiler was also `5.4.0`, which should've been valid. The compiler was rejected because `5.4.0` followed by a year is interpreted as a higher version than a simple `5.4.0`. 